### PR TITLE
Rename Localization IDs to handle typo

### DIFF
--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -29,6 +29,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Pair;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -111,7 +112,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         out.close();
 
         JSONObject response = null;
-        if (conn.getResponseCode() == 200) {
+        if (conn.getResponseCode() == HttpStatus.SC_OK) {
             try {
                 response = SyncHelper.parse(conn.getInputStream());
             } finally {
@@ -186,7 +187,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
             BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line = in.readLine();
 
-            if (conn.getResponseCode() == 200) {
+            if (conn.getResponseCode() == HttpStatus.SC_OK) {
                 if (line.contains("<result>success</result>")) {
                     // Store the authentication token.
                     getCookies(conn);
@@ -491,7 +492,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         SyncHelper.postMulti(conn, parts);
 
         int code = conn.getResponseCode();
-        if (code != 200 && code != 302) {
+        if (code != HttpStatus.SC_OK && code != HttpStatus.SC_MOVED_TEMPORARILY) {
             throw new Exception("got a " + code + " response code from upload");
         }
 

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -101,7 +101,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
             ProtocolException, JSONException {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setDoOutput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
         addCookies(conn);
 
@@ -167,7 +167,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
             HttpURLConnection conn = (HttpURLConnection) new URL(DIGIFIT_URL + "/site/authenticate")
                     .openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             OutputStream out = conn.getOutputStream();
@@ -214,7 +214,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
                     + "&file_type="
                     + fileType;
             HttpURLConnection conn = (HttpURLConnection) new URL(deleteUrl).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             conn.addRequestProperty("Referer", DIGIFIT_URL + "/site/workoutimport");
             addCookies(conn);
         } catch (Exception ex) {
@@ -254,7 +254,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
             String downloadUrl = DIGIFIT_URL + "/workout/download/" + fileId;
 
             HttpURLConnection conn = (HttpURLConnection) new URL(downloadUrl).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             addCookies(conn);
 
             InputStream in = new BufferedInputStream(conn.getInputStream());
@@ -474,7 +474,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     private void uploadFileToDigifit(String payload, String uploadUrl) throws Exception {
         HttpURLConnection conn = (HttpURLConnection) new URL(uploadUrl).openConnection();
         conn.setDoOutput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         addCookies(conn);
 
         String filename = "RunnerUp.tcx";

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -22,6 +22,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -193,7 +194,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == 200 &&
+            if (responseCode == HttpStatus.SC_OK &&
                     "OK".contentEquals(res.getString("_0")) &&
                     res.has("authToken")) {
                 authToken = res.getString("authToken");
@@ -285,7 +286,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == 200 &&
+            if (responseCode == HttpStatus.SC_OK &&
                     "OK".contentEquals(res.getString("_0"))) {
                 s.activityId = mID;
                 return s;
@@ -344,7 +345,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             conn.disconnect();
 
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 parseFeed(feedUpdater, reply);
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -179,7 +179,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             conn = (HttpURLConnection) new URL(login).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             OutputStream wr = new BufferedOutputStream(conn.getOutputStream());
@@ -269,7 +269,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             conn = (HttpURLConnection) new URL(url.toString()).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/octet-stream");
             OutputStream out = new GZIPOutputStream(
                     new BufferedOutputStream(conn.getOutputStream()));
@@ -336,7 +336,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
         Exception ex = null;
         try {
             conn = (HttpURLConnection) new URL(url.toString()).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             final InputStream in = new BufferedInputStream(conn.getInputStream());
             final JSONObject reply = SyncHelper.parse(in);
             int responseCode = conn.getResponseCode();

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -289,7 +289,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
                 .openConnection();
         conn.setDoOutput(true);
         conn.setDoInput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         SyncHelper.postMulti(conn, parts);
 
         int code = conn.getResponseCode();
@@ -343,7 +343,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setDoOutput(true);
         conn.setDoInput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         SyncHelper.postMulti(conn, parts);
 
         int code = conn.getResponseCode();

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -299,7 +300,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         JSONObject ref = SyncHelper.parse(in);
 
         conn.disconnect();
-        if (code != 200) {
+        if (code != HttpStatus.SC_OK) {
             throw new Exception("got " + code + ": >" + msg + "< from createCourse");
         }
 
@@ -353,7 +354,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         JSONObject runRef = SyncHelper.parse(in);
 
         conn.disconnect();
-        if (code != 200) {
+        if (code != HttpStatus.SC_OK) {
             throw new Exception("Got code: " + code + ", msg: " + msg + " from " + url.toString());
         }
 

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -22,6 +22,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -223,7 +224,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 int responseCode = conn.getResponseCode();
                 String amsg = conn.getResponseMessage();
                 getCookies(conn);
-                if (responseCode == 302) {
+                if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
                     String redirect = conn.getHeaderField("Location");
                     conn.disconnect();
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -234,7 +235,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                     responseCode = conn.getResponseCode();
                     amsg = conn.getResponseMessage();
                     getCookies(conn);
-                } else if (responseCode != 200) {
+                } else if (responseCode != HttpStatus.SC_OK) {
                     System.err.println("FunBeatSynchronizer::connect() - got " + responseCode
                             + ", msg: " + amsg);
                 }
@@ -379,7 +380,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             String amsg = conn.getResponseMessage();
             getCookies(conn);
             String redirect = null;
-            if (responseCode == 302) {
+            if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
                 redirect = conn.getHeaderField("Location");
                 conn.disconnect();
                 conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -390,7 +391,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 responseCode = conn.getResponseCode();
                 amsg = conn.getResponseMessage();
                 getCookies(conn);
-            } else if (responseCode != 200) {
+            } else if (responseCode != HttpStatus.SC_OK) {
                 System.err.println("FunBeatSynchronizer::upload() - got " + responseCode + ", msg: "
                         + amsg);
             }
@@ -425,7 +426,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 responseCode = conn.getResponseCode();
                 amsg = conn.getResponseMessage();
                 getCookies(conn);
-                if (responseCode == 302) {
+                if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
                     redirect = conn.getHeaderField("Location");
                     conn.disconnect();
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -504,7 +505,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             final JSONObject reply = SyncHelper.parse(in);
             final int code = conn.getResponseCode();
             conn.disconnect();
-            if (code == 200) {
+            if (code == HttpStatus.SC_OK) {
                 parseFeed(feedUpdater, reply);
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -208,7 +208,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(LOGIN_URL).openConnection();
             conn.setInstanceFollowRedirects(false);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type",
                     "application/x-www-form-urlencoded");
             addCookies(conn);
@@ -229,7 +229,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
                             .openConnection();
                     conn.setInstanceFollowRedirects(false);
-                    conn.setRequestMethod("GET");
+                    conn.setRequestMethod(RequestMethod.GET.name());
                     addCookies(conn);
                     responseCode = conn.getResponseCode();
                     amsg = conn.getResponseMessage();
@@ -304,7 +304,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(API_URL + function).openConnection();
             conn.setDoOutput(true);
             conn.setDoInput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
 
             OutputStream out = new BufferedOutputStream(conn.getOutputStream());
@@ -372,7 +372,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(UPLOAD_URL).openConnection();
             conn.setInstanceFollowRedirects(false);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             addCookies(conn);
             SyncHelper.postMulti(conn, parts);
             int responseCode = conn.getResponseCode();
@@ -385,7 +385,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 conn = (HttpURLConnection) new URL(BASE_URL + redirect)
                         .openConnection();
                 conn.setInstanceFollowRedirects(false);
-                conn.setRequestMethod("GET");
+                conn.setRequestMethod(RequestMethod.GET.name());
                 addCookies(conn);
                 responseCode = conn.getResponseCode();
                 amsg = conn.getResponseMessage();
@@ -412,7 +412,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(surl).openConnection();
             conn.setInstanceFollowRedirects(false);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type",
                     "application/x-www-form-urlencoded");
             addCookies(conn);
@@ -431,7 +431,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
                             .openConnection();
                     conn.setInstanceFollowRedirects(false);
-                    conn.setRequestMethod("GET");
+                    conn.setRequestMethod(RequestMethod.GET.name());
                     addCookies(conn);
                     responseCode = conn.getResponseCode();
                     amsg = conn.getResponseMessage();
@@ -493,7 +493,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(FEED_URL).openConnection();
             conn.setDoInput(true);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/json; charset=utf-8");
             final JSONObject req = getRequestObject();
             final OutputStream out = new BufferedOutputStream(conn.getOutputStream());

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Pair;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -148,9 +149,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             System.err.println("GarminSynchronizer.connect() CHOOSE_URL => code: " + responseCode
                     + ", msg: " + amsg);
 
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 return connectOld();
-            } else if (responseCode == 302) {
+            } else if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
                 return connectNew();
             }
         } catch (MalformedURLException e) {
@@ -186,7 +187,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
             getCookies(conn);
-            if (responseCode != 200) {
+            if (responseCode != HttpStatus.SC_OK) {
                 System.err.println("GarminSynchronizer::connect() - got " + responseCode + ", msg: "
                         + amsg);
             }
@@ -310,9 +311,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             int code = conn.getResponseCode();
             System.err.println("attempt: " + i + " => code: " + code);
             getCookies(conn);
-            if (code == 200)
+            if (code == HttpStatus.SC_OK)
                 break;
-            if (code != 302)
+            if (code != HttpStatus.SC_MOVED_TEMPORARILY)
                 break;
             List<String> fields = conn.getHeaderFields().get("location");
             conn.disconnect();
@@ -387,7 +388,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             SyncHelper.postMulti(conn, parts);
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 JSONObject reply = SyncHelper.parse(new BufferedReader(new InputStreamReader(
                         conn.getInputStream())));
                 conn.disconnect();
@@ -451,7 +452,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 obj = obj.getJSONObject("com.garmin.connect.workout.dto.BaseUserWorkoutListDto");
                 JSONArray arr = obj.getJSONArray("baseUserWorkouts");
                 for (int i = 0;; i++) {
@@ -504,7 +505,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 return;
             }
             ex = new Exception(amsg);

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -206,7 +206,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
 
         conn = (HttpURLConnection) new URL(login).openConnection();
         conn.setDoOutput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
         addCookies(conn);
 
@@ -341,7 +341,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             IOException {
         HttpURLConnection conn = open(base, fv);
         conn.setDoOutput(false);
-        conn.setRequestMethod("GET");
+        conn.setRequestMethod(RequestMethod.GET.name());
         return conn;
     }
 
@@ -349,7 +349,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             IOException {
         HttpURLConnection conn = open(base, fv);
         conn.setDoOutput(true);
-        conn.setRequestMethod("POST");
+        conn.setRequestMethod(RequestMethod.POST.name());
         return conn;
     }
 
@@ -375,7 +375,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             tcx.export(mID, writer);
             conn = (HttpURLConnection) new URL(UPLOAD_URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             addCookies(conn);
             Part<StringWritable> part2 = new Part<StringWritable>("data",
                     new StringWritable(writer.toString()));
@@ -442,7 +442,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
         Exception ex = null;
         try {
             conn = (HttpURLConnection) new URL(LIST_WORKOUTS_URL).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             addCookies(conn);
             conn.connect();
             getCookies(conn);
@@ -485,7 +485,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
         FileOutputStream out = null;
         try {
             conn = (HttpURLConnection) new URL(GET_WORKOUT_URL + key).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             addCookies(conn);
             conn.connect();
             getCookies(conn);

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -20,6 +20,7 @@ package org.runnerup.export;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -188,9 +189,9 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
 
             int code = connect.getResponseCode();
             try {
-                if (code == 500) {
+                if (code == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
                     continue;
-                } else if (code != 200) {
+                } else if (code != HttpStatus.SC_OK) {
                     System.out.println(SyncHelper.parse(new GZIPInputStream(connect.getErrorStream())));
                     status = Status.ERROR;
                     break;
@@ -239,7 +240,7 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
             int code = conn.getResponseCode();
             conn.disconnect();
 
-            if (code != 200) {
+            if (code != HttpStatus.SC_OK) {
                 throw new Exception("got a " + code + " response code from upload");
             } else {
                 JSONArray data = reply.getJSONArray("dataSource");

--- a/app/src/org/runnerup/export/GooglePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/GooglePlusSynchronizer.java
@@ -273,7 +273,7 @@ public class GooglePlusSynchronizer extends DefaultSynchronizer implements Synch
             URL url = new URL(getTokenUrl());
             conn = (HttpURLConnection) url.openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             SyncHelper.postData(conn, fv);

--- a/app/src/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/org/runnerup/export/JoggSESynchronizer.java
@@ -153,7 +153,7 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
 
             conn = (HttpURLConnection) new URL(BASE_URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Host", "jogg.se");
             conn.addRequestProperty("Content-Type", "text/xml");
 
@@ -271,7 +271,7 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
 
             conn = (HttpURLConnection) new URL(BASE_URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Host", "jogg.se");
             conn.addRequestProperty("Content-Type", "text/xml; charset=utf-8");
 

--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -184,7 +184,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
              */
             conn = (HttpURLConnection) new URL(GET_USER_URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             FormValues kv = new FormValues();
@@ -251,7 +251,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
 
             conn = (HttpURLConnection) new URL(IMPORT_URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             FormValues kv = new FormValues();
@@ -296,7 +296,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
 
                 conn = (HttpURLConnection) new URL(UPDATE_URL).openConnection();
                 conn.setDoOutput(true);
-                conn.setRequestMethod("POST");
+                conn.setRequestMethod(RequestMethod.POST.name());
                 conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
                 wr = new BufferedOutputStream(conn.getOutputStream());
                 kv.write(wr);

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -177,7 +177,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             String url = String.format(LOGIN_URL, CLIENT_ID, CLIENT_SECRET, APP_ID);
             conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("user-agent", USER_AGENT);
             conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             conn.addRequestProperty("Accept", "application/json");
@@ -252,7 +252,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             String url = String.format(SYNC_URL, access_token);
             conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("user-agent", USER_AGENT);
             conn.addRequestProperty("appid", APP_ID);
             Part<StringWritable> part1 = new Part<StringWritable>("runXML",
@@ -282,7 +282,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             url = String.format(SYNC_COMPLETE_URL, access_token);
             conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("user-agent", USER_AGENT);
             conn.addRequestProperty("appid", APP_ID);
 
@@ -350,7 +350,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
         HttpURLConnection conn = null;
         try {
             conn = (HttpURLConnection) new URL(url).openConnection();
-            conn.setRequestMethod("GET");
+            conn.setRequestMethod(RequestMethod.GET.name());
             conn.addRequestProperty("Accept", "application/json");
             conn.addRequestProperty("User-Agent", USER_AGENT);
             conn.addRequestProperty("appid", APP_ID);

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -22,6 +22,7 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -275,7 +276,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             String amsg = conn.getResponseMessage();
             conn.connect();
 
-            if (responseCode != 200) {
+            if (responseCode != HttpStatus.SC_OK) {
                 throw new Exception(amsg);
             }
 
@@ -289,7 +290,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             responseCode = conn.getResponseCode();
             amsg = conn.getResponseMessage();
             conn.disconnect();
-            if (responseCode == 200) {
+            if (responseCode == HttpStatus.SC_OK) {
                 s = Status.OK;
                 s.activityId = mID;
                 return s;
@@ -358,7 +359,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             final JSONObject reply = SyncHelper.parse(in);
             final int code = conn.getResponseCode();
             conn.disconnect();
-            if (code == 200)
+            if (code == HttpStatus.SC_OK)
                 return reply;
         } finally {
             if (conn != null)

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -426,7 +426,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
             String amsg = conn.getResponseMessage();
             conn.disconnect();
             conn = null;
-            if (responseCode >= 200 && responseCode < 300) {
+            if (responseCode >= HttpStatus.SC_OK && responseCode < HttpStatus.SC_MULTIPLE_CHOICES) {
                 s = Status.OK;
                 s.activityId = mID;
                 return s;

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -235,7 +236,7 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
             if (!found) {
                 System.err.println("Unhandled response from RunningAHEADSynchronizer: " + obj);
             }
-            if (responseCode == 200 && found) {
+            if (responseCode == HttpStatus.SC_OK && found) {
                 conn.disconnect();
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -204,7 +204,7 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
             tcx.export(mID, writer);
             conn = (HttpURLConnection) new URL(URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Content-Encoding", "gzip");
             OutputStream out = new GZIPOutputStream(
                     new BufferedOutputStream(conn.getOutputStream()));

--- a/app/src/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/org/runnerup/export/RuntasticSynchronizer.java
@@ -189,7 +189,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(LOGIN_URL).openConnection();
             conn.setInstanceFollowRedirects(false);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             addRequestHeaders(conn);
             conn.addRequestProperty("Content-Type",
                     "application/x-www-form-urlencoded");
@@ -236,7 +236,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
                 url2 = url2 + "?authenticity_token=" + SyncHelper.URLEncode(authToken);
                 conn = (HttpURLConnection) new URL(url2).openConnection();
                 conn.setInstanceFollowRedirects(false);
-                conn.setRequestMethod("GET");
+                conn.setRequestMethod(RequestMethod.GET.name());
                 conn.setRequestProperty("Host", "www.runtastic.com");
                 conn.addRequestProperty("Accept", "application/json");
                 InputStream in = new BufferedInputStream(conn.getInputStream());
@@ -290,7 +290,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
             conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setInstanceFollowRedirects(false);
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
             conn.addRequestProperty("Host", "www.runtastic.com");
             conn.addRequestProperty("X-Requested-With", "XMLHttpRequest");
             conn.addRequestProperty("X-File-Name", filename);
@@ -325,7 +325,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
             if (sport != null && sport != Sport.RUNNING && sport2runtasticMap.containsKey(sport)) {
                 conn = (HttpURLConnection) new URL(UPDATE_SPORTS_TYPE).openConnection();
                 conn.setDoOutput(true);
-                conn.setRequestMethod("POST");
+                conn.setRequestMethod(RequestMethod.POST.name());
                 conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded");
                 conn.addRequestProperty("X-Requested-With", "XMLHttpRequest");
                 addRequestHeaders(conn);

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 
+import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -224,7 +225,7 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
             BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             JSONObject obj = SyncHelper.parse(in);
 
-            if (responseCode == 201 && obj.getLong("id") > 0) {
+            if (responseCode == HttpStatus.SC_CREATED && obj.getLong("id") > 0) {
                 conn.disconnect();
                 s = Status.OK;
                 s.activityId = mID;

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -202,7 +202,7 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
             tcx.export(mID, writer);
             conn = (HttpURLConnection) new URL(URL).openConnection();
             conn.setDoOutput(true);
-            conn.setRequestMethod("POST");
+            conn.setRequestMethod(RequestMethod.POST.name());
 
             Part<StringWritable> part0 = new Part<StringWritable>("access_token",
                     new StringWritable(access_token));

--- a/app/src/org/runnerup/export/oauth2client/OAuth2Activity.java
+++ b/app/src/org/runnerup/export/oauth2client/OAuth2Activity.java
@@ -36,6 +36,7 @@ import android.webkit.WebViewClient;
 
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.export.Synchronizer;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.SyncHelper;
 
@@ -216,7 +217,7 @@ public class OAuth2Activity extends Activity {
                                 URL newUrl = new URL(token_url);
                                 conn = (HttpURLConnection) newUrl.openConnection();
                                 conn.setDoOutput(true);
-                                conn.setRequestMethod("POST");
+                                conn.setRequestMethod(Synchronizer.RequestMethod.POST.name());
                                 conn.setRequestProperty("Content-Type",
                                         "application/x-www-form-urlencoded");
                                 {


### PR DESCRIPTION
Hi,

As stated in issue #113, Android seems to support having ID with both `time` and `Time`. It is much easier to see what is the expected text when IDs follow English text so I reformatted code to the convention:

English text: A very long text (with stuff) ##and other
ID: A_very_long_text_with_stuff_and_other

Except for `array.xml`.

I made several commits, but it could be only one... what do you think @jonasoreland?

It merged, you can close issue accordingly.
